### PR TITLE
Add Blockly.FieldCharInput

### DIFF
--- a/src/core/blockly.js
+++ b/src/core/blockly.js
@@ -43,6 +43,7 @@ goog.require('Blockly.FieldNumberBinary');
 goog.require('Blockly.FieldVariable');
 // Modification by DigiPen Institute of Technology
 goog.require('Blockly.FieldProcedure');
+goog.require('Blockly.FieldCharInput');
 // end modification
 goog.require('Blockly.Generator');
 goog.require('Blockly.Msg');


### PR DESCRIPTION
Add missing goog.require('Blockly.FieldCharInput'); to blockly.js allowing build.py to find it. Resolves #9